### PR TITLE
Added NodeWithEffects to the exports.

### DIFF
--- a/fxr.ts
+++ b/fxr.ts
@@ -14557,6 +14557,7 @@ export {
   StateCondition,
 
   Node,
+  NodeWithEffects,
   RootNode,
   ProxyNode,
   LevelOfDetailNode,


### PR DESCRIPTION
This was stopping its descendants from showing up in the hierarchy.